### PR TITLE
fix: fix deadloop when connecting to single server with cluster config

### DIFF
--- a/src/mongoc/mc_monitor.erl
+++ b/src/mongoc/mc_monitor.erl
@@ -122,7 +122,7 @@ next_loop(Pid) ->
 %% @private
 loop(State = #state{type = Type, host = Host, port = Port, topology = Topology, server = Server,
   connect_to = Timeout, heartbeatF = HB_MS, minHeartbeatF = MinHB_MS, counter = Counter, worker_opts = WOpts}) ->
-  ConnectArgs = form_args(Host, Port, Timeout, WOpts),
+  ConnectArgs = mc_util:form_connect_args(Host, Port, Timeout, WOpts),
   try check(ConnectArgs, Server) of
     Res ->
       gen_server:cast(Topology, Res),
@@ -172,11 +172,3 @@ do_timeout(Pid, _TO) ->
 %% @private
 send_stop(undefined) -> ok;
 send_stop(PausePid) -> PausePid ! stop.
-
-%% @private
-form_args(Host, Port, Timeout, WorkerArgs) ->
-  case mc_utils:get_value(ssl, WorkerArgs, false) of
-    true -> [{host, Host}, {port, Port}, {timeout, Timeout}, {ssl, true},
-      {ssl_opts, mc_utils:get_value(ssl_opts, WorkerArgs, [])}];
-    false -> [{host, Host}, {port, Port}, {timeout, Timeout}]
-  end.

--- a/src/mongoc/mc_server.erl
+++ b/src/mongoc/mc_server.erl
@@ -57,7 +57,7 @@ start(Topology, HostPort, Topts, Wopts) ->
 
 init([Topology, Addr, TopologyOptions, Wopts]) ->
   process_flag(trap_exit, true),
-  {Host, Port} = parse_seed(Addr),
+  {Host, Port} = mc_util:parse_seed(Addr),
   PoolConf = form_pool_conf(TopologyOptions),
   ConnectTimeoutMS = mc_utils:get_value(connectTimeoutMS, TopologyOptions, 20000),
   SocketTimeoutMS = mc_utils:get_value(socketTimeoutMS, TopologyOptions, 100),
@@ -172,17 +172,6 @@ init_pool(#state{host = Host, port = Port, pool_conf = Conf, worker_opts = Wopts
   {ok, Child} = poolboy:start_link(PoolArgs, WO),
   link(Child),
   Child.
-
-%% @private
-parse_seed(Addr) when is_binary(Addr) ->
-  parse_seed(binary_to_list(Addr));
-parse_seed(Addr) when is_list(Addr) ->
-  [Host0, Port] = string:split(Addr, ":", trailing),
-  Host = case inet:parse_address(Host0) of
-             {ok, H} -> H;
-             _ -> Host0
-         end,
-  {Host, list_to_integer(Port)}.
 
 %% @private
 form_pool_conf(TopologyOptions) ->

--- a/src/mongoc/mc_util.erl
+++ b/src/mongoc/mc_util.erl
@@ -1,0 +1,35 @@
+%%%-------------------------------------------------------------------
+%%% @author mononym
+%%% @copyright (C) 2022, <COMPANY>
+%%% @doc
+%%% helper functions accessed from various modules
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mc_util).
+
+-include("mongoc.hrl").
+
+%% API
+-export([form_connect_args/4, parse_seed/1]).
+
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+form_connect_args(Host, Port, Timeout, WorkerArgs) ->
+  case mc_utils:get_value(ssl, WorkerArgs, false) of
+    true -> [{host, Host}, {port, Port}, {timeout, Timeout}, {ssl, true},
+      {ssl_opts, mc_utils:get_value(ssl_opts, WorkerArgs, [])}];
+    false -> [{host, Host}, {port, Port}, {timeout, Timeout}]
+  end.
+
+parse_seed(Addr) when is_binary(Addr) ->
+  parse_seed(binary_to_list(Addr));
+parse_seed(Addr) when is_list(Addr) ->
+  [Host0, Port] = string:split(Addr, ":", trailing),
+  Host = case inet:parse_address(Host0) of
+             {ok, H} -> H;
+             _ -> Host0
+         end,
+  {Host, list_to_integer(Port)}.

--- a/src/mongodb.app.src
+++ b/src/mongodb.app.src
@@ -1,7 +1,7 @@
 %% ex: ts=4 sw=4 noexpandtab syntax=erlang
 {application, mongodb, [
   {description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
-  {vsn, "3.0.11"},
+  {vsn, "3.0.12"},
   {registered, []},
   {applications, [kernel, stdlib, bson, crypto, poolboy, pbkdf2]},
   {mod, {mongo_app, []}}

--- a/src/mongodb.appup.src
+++ b/src/mongodb.appup.src
@@ -1,13 +1,35 @@
 %% -*- mode: erlang -*-
-{"3.0.11",
+{"3.0.12",
  [
-  {"3.0.10", []},
+  {"3.0.11", [
+    {add_module, mc_util},
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
+  ]},
+  {"3.0.10", [
+    {add_module, mc_util},
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
+  ]},
   {"3.0.9", [
-    {load_module, mc_worker_logic, brutal_purge, soft_purge, []}
+    {add_module, mc_util},
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_logic, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.8", [
+    {add_module, mc_util},
     {load_module, mc_worker_logic, brutal_purge, soft_purge, []},
-    {load_module, mc_monitor, brutal_purge, soft_purge, []}
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {<<"3.0.[0-7]">>, [
     {restart_application, mongodb}
@@ -15,13 +37,35 @@
   {<<".*">>, []}
  ],
  [
-  {"3.0.10", []},
+  {"3.0.11", [
+    {delete_module, mc_util},
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
+  ]},
+  {"3.0.10", [
+    {delete_module, mc_util},
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
+  ]},
   {"3.0.9", [
-    {load_module, mc_worker_logic, brutal_purge, soft_purge, []}
+    {delete_module, mc_util},
+    {load_module, mc_worker_logic, brutal_purge, soft_purge, []},
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.8", [
+    {delete_module, mc_util},
     {load_module, mc_worker_logic, brutal_purge, soft_purge, []},
-    {load_module, mc_monitor, brutal_purge, soft_purge, []}
+    {load_module, mc_monitor, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {<<"3.0.[0-7]">>, [
     {restart_application, mongodb}


### PR DESCRIPTION
A deadloop is created when an invalid connection config, by specifying the wrong mongo_type and/or incorrect set names, is used to connect to a server/cluster. This happens because the `mc_topology` worker spawns the `mc_server` and `mc_monitor` processes which end up triggering a method on the `mc_topology` gen server which kills the `mc_server` process when there is a mismatch between the config and what is returned from the connected server/cluster.

However on receiving the `'EXIT'` message from the monitored `mc_server` process, the `mc_topology` worker instantly restarts it and the whole thing starts all over again. This is a very tight loop and will end up causing severe problems if not detected right away and currently it's not simple to detect that a misconfiguration is the cause.

The only way to detect whether this is the cause would be to do the same check while the `mc_topology` worker is starting up which is what this code does. By doing this we can stop the connection call to `mongo_api` or `mongoc` from ever succeeding and return a meaningful error that can be used to indicate that the connection will never succeed as configured.

With this code change a bad configuration will return an error that looks something like this: `{configured_mongo_type_mismatch,replicaSetNoPrimary,standalone}`

Where the second value of the tuple is the type as defined in the connection configuration and the last value is what the Mongo server is configured as. A setName mismatch will return the following error: `{configured_mongo_set_name_mismatch, ConfigurationSetName, ServerSetName}`

The checks added in the `mc_topology_logics` module **should** match all of the checks made higher up in the file in the `update_topology_state` method that cause an `exit`.