### PR TITLE
fix(mc_topology): fix potential process leaks

### DIFF
--- a/src/mongoc/mc_topology.erl
+++ b/src/mongoc/mc_topology.erl
@@ -13,7 +13,7 @@
 -include("mongoc.hrl").
 
 %% API
--export([start_link/3, drop_server/2, update_topology/1, get_state/1, get_pool/2, get_pool/5, get_pool/1, disconnect/1, get_state_part/1]).
+-export([start_link/3, drop_server/2, update_topology/1, get_state/1, get_pool/2, get_pool/4, get_pool/5, get_pool/1, disconnect/1, get_state_part/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
@@ -128,6 +128,16 @@ get_pool(RPMode, RPTags, State) ->
       mc_topology:update_topology(State#topology_state.self),
       {error, timeout}
   end.
+
+get_pool(From, #topology_state{self = Topology, get_pool_timeout = TM} = State, RPMode, Tags) ->
+    case mc_selecting_logics:select_server(Topology, RPMode, Tags) of
+        #mc_server{pid = Pid, type = Type} ->
+            Pool = mc_server:get_pool(Pid, TM),
+            From ! {self(), Pool, Type};
+        undefined ->
+            timer:sleep(100),
+            get_pool(From, State, RPMode, Tags)
+    end.
 
 get_pool(From, #topology_state{self = Topology, get_pool_timeout = TM} = State, RPMode, Tags, Caller) ->
   case is_process_alive(Caller) of

--- a/src/mongoc/mc_topology.erl
+++ b/src/mongoc/mc_topology.erl
@@ -130,27 +130,27 @@ get_pool(RPMode, RPTags, State) ->
   end.
 
 get_pool(From, #topology_state{self = Topology, get_pool_timeout = TM} = State, RPMode, Tags) ->
-    case mc_selecting_logics:select_server(Topology, RPMode, Tags) of
-        #mc_server{pid = Pid, type = Type} ->
-            Pool = mc_server:get_pool(Pid, TM),
-            From ! {self(), Pool, Type};
-        undefined ->
-            timer:sleep(100),
-            get_pool(From, State, RPMode, Tags)
-    end.
+  case mc_selecting_logics:select_server(Topology, RPMode, Tags) of
+    #mc_server{pid = Pid, type = Type} ->
+      Pool = mc_server:get_pool(Pid, TM),
+      From ! {self(), Pool, Type};
+    undefined ->
+      timer:sleep(100),
+      get_pool(From, State, RPMode, Tags)
+  end.
 
 get_pool(From, #topology_state{self = Topology, get_pool_timeout = TM} = State, RPMode, Tags, Caller) ->
   case is_process_alive(Caller) of
-      false -> ok;
-      true ->
-          case mc_selecting_logics:select_server(Topology, RPMode, Tags) of
-            #mc_server{pid = Pid, type = Type} ->
-              Pool = mc_server:get_pool(Pid, TM),
-              From ! {self(), Pool, Type};
-            undefined ->
-              timer:sleep(100),
-              get_pool(From, State, RPMode, Tags, Caller)
-          end
+    false -> ok;
+    true ->
+      case mc_selecting_logics:select_server(Topology, RPMode, Tags) of
+        #mc_server{pid = Pid, type = Type} ->
+          Pool = mc_server:get_pool(Pid, TM),
+          From ! {self(), Pool, Type};
+        undefined ->
+          timer:sleep(100),
+          get_pool(From, State, RPMode, Tags, Caller)
+      end
   end.
 
 

--- a/src/mongoc/mc_topology.erl
+++ b/src/mongoc/mc_topology.erl
@@ -115,7 +115,7 @@ get_pool(Topology, Options) ->
 get_pool(RPMode, RPTags, State) ->
   TO = State#topology_state.topology_opts,
   ServerSelectionTimeoutMS = mc_utils:get_value(serverSelectionTimeoutMS, TO, 30000),
-  Pid = spawn(?MODULE, get_pool, [self(), State, RPMode, RPTags]),
+  Pid = proc_lib:spawn_link(?MODULE, get_pool, [self(), State, RPMode, RPTags]),
   receive
     {Pid, {error, Reason}, _} ->
       {error, Reason};

--- a/src/mongodb.app.src
+++ b/src/mongodb.app.src
@@ -1,7 +1,7 @@
 %% ex: ts=4 sw=4 noexpandtab syntax=erlang
 {application, mongodb, [
   {description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
-  {vsn, "3.0.12"},
+  {vsn, "3.0.13"},
   {registered, []},
   {applications, [kernel, stdlib, bson, crypto, poolboy, pbkdf2]},
   {mod, {mongo_app, []}}

--- a/src/mongodb.appup.src
+++ b/src/mongodb.appup.src
@@ -1,6 +1,8 @@
 %% -*- mode: erlang -*-
-{"3.0.12",
- [
+{"3.0.13",
+ [{"3.0.12", [
+    {load_module, mc_topology, brutal_purge, soft_purge, []}
+  ]},
   {"3.0.11", [
     {add_module, mc_util},
     {load_module, mc_monitor, brutal_purge, soft_purge, []},
@@ -37,6 +39,9 @@
   {<<".*">>, []}
  ],
  [
+  {"3.0.12", [
+    {load_module, mc_topology, brutal_purge, soft_purge, []}
+  ]},
   {"3.0.11", [
     {delete_module, mc_util},
     {load_module, mc_monitor, brutal_purge, soft_purge, []},


### PR DESCRIPTION
If the process where get_pool is located is killed before the timeout, there will be no chance to send timeout information to the spawn's get_pool process. This will cause the get_pool process to leak.