### PR TITLE
Fix auth logic

### DIFF
--- a/src/connection/mc_auth_logic.erl
+++ b/src/connection/mc_auth_logic.erl
@@ -42,7 +42,7 @@ mongodb_cr_auth(Socket, Database, Login, Password, SetOpts) ->
   Nonce = maps:get(<<"nonce">>, Res),
   case mc_worker_api:sync_command(Socket, Database, ?AUTH_CMD(Login, Nonce, Password), SetOpts) of
     {true, _} -> true;
-    {false, Reason} -> {false, Reason}
+    {false, Reason} -> logger:error("Can't pass authentification for reason: ~p", [Reason]), {false, Reason}
   end.
 
 %% @private

--- a/src/connection/mc_auth_logic.erl
+++ b/src/connection/mc_auth_logic.erl
@@ -42,7 +42,7 @@ mongodb_cr_auth(Socket, Database, Login, Password, SetOpts) ->
   Nonce = maps:get(<<"nonce">>, Res),
   case mc_worker_api:sync_command(Socket, Database, ?AUTH_CMD(Login, Nonce, Password), SetOpts) of
     {true, _} -> true;
-    {false, Reason} -> erlang:error(Reason)
+    {false, Reason} -> {false, Reason}
   end.
 
 %% @private
@@ -60,19 +60,27 @@ scram_first_step(Socket, Database, Login, Password, SetOpts) ->
   RandomBString = mc_utils:random_binary(?RANDOM_LENGTH),
   FirstMessage = compose_first_message(Login, RandomBString),
   Message = base64:encode(<<?GS2_HEADER/binary, FirstMessage/binary>>),
-  {true, Res} = mc_worker_api:sync_command(Socket, Database,
-    {<<"saslStart">>, 1, <<"mechanism">>, <<"SCRAM-SHA-1">>, <<"autoAuthorize">>, 1, <<"payload">>, Message}, SetOpts),
-  ConversationId = maps:get(<<"conversationId">>, Res, {}),
-  Payload = maps:get(<<"payload">>, Res),
-  scram_second_step(Socket, Database, Login, Password, Payload, ConversationId, RandomBString, FirstMessage, SetOpts).
+  Command = {<<"saslStart">>, 1, <<"mechanism">>, <<"SCRAM-SHA-1">>, <<"autoAuthorize">>, 1, <<"payload">>, Message},
+  case mc_worker_api:sync_command(Socket, Database, Command, SetOpts) of
+    {true, Res} ->
+      ConversationId = maps:get(<<"conversationId">>, Res, {}),
+      Payload = maps:get(<<"payload">>, Res),
+      scram_second_step(Socket, Database, Login, Password, Payload, ConversationId, RandomBString, FirstMessage, SetOpts);
+    {false, Reason} ->
+      {false, Reason}
+  end.
 
 %% @private
 scram_second_step(Socket, Database, Login, Password, Payload, ConversationId, RandomBString, FirstMessage, SetOpts) ->
   Decoded = base64:decode(Payload),
   {Signature, ClientFinalMessage} = compose_second_message(Decoded, Login, Password, RandomBString, FirstMessage),
-  {true, Res} = mc_worker_api:sync_command(Socket, Database, {<<"saslContinue">>, 1, <<"conversationId">>, ConversationId,
-    <<"payload">>, base64:encode(ClientFinalMessage)}, SetOpts),
-  scram_third_step(base64:encode(Signature), Res, ConversationId, Socket, Database, SetOpts).
+  Command = {<<"saslContinue">>, 1, <<"conversationId">>, ConversationId, <<"payload">>, base64:encode(ClientFinalMessage)},
+  case mc_worker_api:sync_command(Socket, Database, Command, SetOpts) of
+    {true, Res} ->
+      scram_third_step(base64:encode(Signature), Res, ConversationId, Socket, Database, SetOpts);
+    {false, Reason} ->
+      {false, Reason}
+  end.
 
 %% @private
 scram_third_step(ServerSignature, Response, ConversationId, Socket, Database, SetOpts) ->
@@ -85,9 +93,13 @@ scram_third_step(ServerSignature, Response, ConversationId, Socket, Database, Se
 %% @private
 scram_forth_step(true, _, _, _, _) -> true;
 scram_forth_step(false, ConversationId, Socket, Database, SetOpts) ->
-  {true, Res} = mc_worker_api:sync_command(Socket, Database, {<<"saslContinue">>, 1, <<"conversationId">>,
-    ConversationId, <<"payload">>, <<>>}, SetOpts),
-  true = maps:get(<<"done">>, Res, false).
+  Command = {<<"saslContinue">>, 1, <<"conversationId">>, ConversationId, <<"payload">>, <<>>},
+  case mc_worker_api:sync_command(Socket, Database, Command, SetOpts) of
+    {true, Res} ->
+      true = maps:get(<<"done">>, Res, false);
+    {false, Reason} ->
+      {false, Reason}
+  end.
 
 %% @private
 compose_first_message(Login, RandomBString) ->

--- a/src/connection/mc_worker.erl
+++ b/src/connection/mc_worker.erl
@@ -51,12 +51,11 @@ init(Options) ->
       Login = mc_utils:get_value(login, Options),
       Password = mc_utils:get_value(password, Options),
       NextReqFun = mc_utils:get_value(next_req_fun, Options, fun() -> ok end),
-      auth_if_credentials(Socket, ConnState, NetModule, Login, Password),
-      gen_server:enter_loop(?MODULE, [],
-        #state{socket = Socket,
-          conn_state = ConnState,
-          net_module = NetModule,
-          next_req_fun = NextReqFun});
+      InitState = #state{socket = Socket, conn_state = ConnState, net_module = NetModule, next_req_fun = NextReqFun},
+      case auth_if_credentials(Socket, ConnState, NetModule, Login, Password) of
+        true -> gen_server:enter_loop(?MODULE, [], InitState);
+        {false, Reason} -> proc_lib:init_ack(Reason)
+      end;
     Error ->
       proc_lib:init_ack(Error)
   end.
@@ -213,8 +212,7 @@ get_set_opts_module(Options) ->
 
 %% @private
 auth_if_credentials(_, _, _, Login, Password) when Login =:= undefined; Password =:= undefined ->
-  ok;
+  true;
 auth_if_credentials(Socket, ConnState, NetModule, Login, Password) ->
   Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.auth_source, NetModule),
-  mc_auth_logic:auth(Version, Socket, ConnState#conn_state.auth_source, Login, Password, NetModule),
-  ok.
+  mc_auth_logic:auth(Version, Socket, ConnState#conn_state.auth_source, Login, Password, NetModule).

--- a/src/connection/mc_worker.erl
+++ b/src/connection/mc_worker.erl
@@ -54,7 +54,7 @@ init(Options) ->
       InitState = #state{socket = Socket, conn_state = ConnState, net_module = NetModule, next_req_fun = NextReqFun},
       case auth_if_credentials(Socket, ConnState, NetModule, Login, Password) of
         true -> gen_server:enter_loop(?MODULE, [], InitState);
-        {false, Reason} -> proc_lib:init_ack(Reason)
+        {false, Reason} -> exit(self(), Reason)
       end;
     Error ->
       proc_lib:init_ack(Error)


### PR DESCRIPTION
Just exit when auth failed.
Notice that the `poolboy_sup` used `simple_one_for_one` sup flag, the client process will still be restarted continuously.