### PR TITLE
feat: add mongo_api:ping/2

### DIFF
--- a/src/api/mc_worker_api.erl
+++ b/src/api/mc_worker_api.erl
@@ -29,7 +29,8 @@
 -export([
   count/3,
   count/4,
-  count/2]).
+  count/2
+  ]).
 -export([
   command/2,
   command/3,

--- a/src/api/mongo_api.erl
+++ b/src/api/mongo_api.erl
@@ -26,6 +26,7 @@
   update/5,
   delete/3,
   count/4,
+  command/3,
   ensure_index/3,
   disconnect/1]).
 
@@ -105,6 +106,14 @@ count(Topology, Collection, Selector, Limit) ->
       mc_worker_api:count(Worker, Query)
     end,
     #{}).
+
+-spec command(atom() | pid(), selector(), timeout()) -> transaction_result(integer()).
+command(Topology, Command, Timeout) ->
+  mongoc:transaction_query(Topology,
+    fun(Conf = #{pool := Worker}) ->
+      Query = mongoc:command_query(Conf, Command),
+      mc_worker_api:command(Worker, Query)
+    end, #{}, Timeout).
 
 %% @doc Creates index on collection according to given spec.
 %%      The key specification is a bson documents with the following fields:

--- a/src/api/mongoc.erl
+++ b/src/api/mongoc.erl
@@ -23,6 +23,7 @@
   append_read_preference/2,
   find_query/6,
   count_query/4,
+  command_query/2,
   find_one_query/5]).
 
 
@@ -122,6 +123,14 @@ count_query(#{server_type := ServerType, read_preference := RPrefs}, Coll, Selec
 count_query(#{server_type := ServerType, read_preference := RPrefs}, Coll, Selector, Limit) ->
   Command =
     {<<"count">>, mc_utils:value_to_binary(Coll), <<"query">>, Selector, <<"limit">>, Limit},
+  Q = #'query'{
+    collection = <<"$cmd">>,
+    selector = Command
+  },
+  mongos_query_transform(ServerType, Q, RPrefs).
+
+-spec command_query(map(), selector()) -> query().
+command_query(#{server_type := ServerType, read_preference := RPrefs}, Command) ->
   Q = #'query'{
     collection = <<"$cmd">>,
     selector = Command

--- a/src/mongodb.app.src
+++ b/src/mongodb.app.src
@@ -1,7 +1,7 @@
 %% ex: ts=4 sw=4 noexpandtab syntax=erlang
 {application, mongodb, [
   {description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
-  {vsn, "3.0.16"},
+  {vsn, "3.0.17"},
   {registered, []},
   {applications, [kernel, stdlib, bson, crypto, poolboy, pbkdf2]},
   {mod, {mongo_app, []}}

--- a/src/mongodb.appup.src
+++ b/src/mongodb.appup.src
@@ -1,24 +1,35 @@
 %% -*- mode: erlang -*-
-{"3.0.16",
- [{"3.0.15", [
+{"3.0.17",
+ [{"3.0.16", [
+    {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []}
+  ]},
+  {"3.0.15", [
+    {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.14", [
+    {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
-    {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
-    {load_module, mongoc, brutal_purge, soft_purge, []}
+    {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.13", [
-    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
     {load_module, mc_util, brutal_purge, soft_purge, []}
   ]},
   {"3.0.12", [
-    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
     {load_module, mc_util, brutal_purge, soft_purge, []},
@@ -27,8 +38,9 @@
   ]},
   {"3.0.11", [
     {add_module, mc_util},
-    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
     {load_module, mc_monitor, brutal_purge, soft_purge, []},
@@ -38,8 +50,9 @@
   ]},
   {"3.0.10", [
     {add_module, mc_util},
-    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
     {load_module, mc_monitor, brutal_purge, soft_purge, []},
@@ -49,8 +62,9 @@
   ]},
   {"3.0.9", [
     {add_module, mc_util},
-    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
     {load_module, mc_monitor, brutal_purge, soft_purge, []},
@@ -61,8 +75,9 @@
   ]},
   {"3.0.8", [
     {add_module, mc_util},
-    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
     {load_module, mc_worker_logic, brutal_purge, soft_purge, []},
@@ -76,15 +91,25 @@
   ]},
   {<<".*">>, []}
  ],
- [{"3.0.15", [
+ [{"3.0.16", [
+    {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []}
+  ]},
+  {"3.0.15", [
+    {load_module, mongoc, brutal_purge, soft_purge, []},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.14", [
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []}
   ]},
   {"3.0.13", [
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
@@ -93,6 +118,7 @@
     {load_module, mc_util, brutal_purge, soft_purge, []}
   ]},
   {"3.0.12", [
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
@@ -103,6 +129,7 @@
   ]},
   {"3.0.11", [
     {delete_module, mc_util},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
@@ -114,6 +141,7 @@
   ]},
   {"3.0.10", [
     {delete_module, mc_util},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
@@ -125,6 +153,7 @@
   ]},
   {"3.0.9", [
     {delete_module, mc_util},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
@@ -137,6 +166,7 @@
   ]},
   {"3.0.8", [
     {delete_module, mc_util},
+    {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},


### PR DESCRIPTION
Add `mongo_api:ping/2` for health check purposes. It will be called by the `emqx_backend_mongo_actions:on_get_resource_status` to test if the connection between emqx and mongodb works well.

Before this change, we have to use `mongo_api:find_one(Conn, <<"foo">>, {}, #{}, 0, infinity)` to test the connectivity, where <<"foo">> is a dummy collection may or may not be present in the mongodb.