### PR TITLE
fix: start mc_workers in parallel

### DIFF
--- a/src/mongoc/mc_topology.erl
+++ b/src/mongoc/mc_topology.erl
@@ -39,7 +39,7 @@ init([SeedsList, TopologyOptions, WorkerOptions]) ->
   LocalThresholdMS = mc_utils:get_value(localThresholdMS, TopologyOptions, 200),
   RPmode = mc_utils:get_value(rp_mode, TopologyOptions, primary),
   RPTags = mc_utils:get_value(tags, TopologyOptions, []),
-  GetPoolTimeout = mc_utils:get_value(get_pool_timeout, TopologyOptions, 5000),
+  GetPoolTimeout = mc_utils:get_value(get_pool_timeout, TopologyOptions, 30000),
   Servers = ets:new(mc_servers, [set, {keypos, 2}]),
   State = #topology_state{
     self = self(),

--- a/src/mongodb.appup.src
+++ b/src/mongodb.appup.src
@@ -3,18 +3,30 @@
  [{"3.0.16", [
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_worker_api, brutal_purge, soft_purge, []},
-    {load_module, mongo_api, brutal_purge, soft_purge, []}
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_util, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []}
   ]},
   {"3.0.15", [
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
+    {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_util, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.14", [
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
+    {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_util, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.13", [
@@ -23,6 +35,8 @@
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
     {load_module, mc_util, brutal_purge, soft_purge, []}
   ]},
@@ -32,6 +46,7 @@
     {load_module, mongo_api, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
     {load_module, mc_util, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
     {load_module, mc_topology, brutal_purge, soft_purge, []}
@@ -94,17 +109,29 @@
  [{"3.0.16", [
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_worker_api, brutal_purge, soft_purge, []},
-    {load_module, mongo_api, brutal_purge, soft_purge, []}
+    {load_module, mongo_api, brutal_purge, soft_purge, []},
+    {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_util, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []}
   ]},
   {"3.0.15", [
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
+    {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_util, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []}
   ]},
   {"3.0.14", [
     {load_module, mc_worker_api, brutal_purge, soft_purge, []},
     {load_module, mongo_api, brutal_purge, soft_purge, []},
+    {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
+    {load_module, mc_util, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
     {load_module, mongoc, brutal_purge, soft_purge, []}
   ]},
@@ -114,6 +141,8 @@
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
+    {load_module, mc_topology, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
     {load_module, mc_util, brutal_purge, soft_purge, []}
   ]},
@@ -123,6 +152,7 @@
     {load_module, mongoc, brutal_purge, soft_purge, []},
     {load_module, mc_auth_logic, brutal_purge, soft_purge, []},
     {load_module, mc_worker, brutal_purge, soft_purge, []},
+    {load_module, mc_server, brutal_purge, soft_purge, []},
     {load_module, mc_util, brutal_purge, soft_purge, []},
     {load_module, mc_topology_logics, brutal_purge, soft_purge, []},
     {load_module, mc_topology, brutal_purge, soft_purge, []}


### PR DESCRIPTION
fix: start mc_workers in parallel

Speedup the connection establishment to MongoDB.
Before this change, the total time it spend will be `pool_size` * (`tcp_establish_time` + `auth_time`)