### PR TITLE
perf: use `application:get_env/3` instead of `application:get_env/1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To authenticate use function `mc_worker_api:connect`, or
 By default timeout for all connections to connection gen_server is `infinity`.
 If you found problems with it - you can
 modify timeout.
-To modify it just add `mc_worker_call_timeout` with new value to your
+To modify it just add `mc_worker_call_timeout` with new value to `mongodb`
  applications's env config.
 
 Timeout for operations with cursors may be explicity passed to `mc_cursor:next/2`,

--- a/src/support/mc_utils.erl
+++ b/src/support/mc_utils.erl
@@ -65,10 +65,7 @@ value_to_binary(_Value) ->
   <<>>.
 
 get_timeout() ->
-  case application:get_env(mc_worker_call_timeout) of
-    {ok, Time} -> Time;
-    undefined -> infinity
-  end.
+   application:get_env(mongodb, mc_worker_call_timeout, infinity).
 
 use_legacy_protocol(Connection) ->
     %% Latest MongoDB version that supported the non-op-msg based protocol was


### PR DESCRIPTION
`application:get_env/1` calls `ets:match/2` on `ac_tab` and can be very inefficient.