### PR TITLE
MongoDB 8.2 requires authentication to run command buildInfo (get_version).

### DIFF
--- a/src/connection/mc_auth_logic.erl
+++ b/src/connection/mc_auth_logic.erl
@@ -26,7 +26,7 @@
   }).
 
 %% API
--export([auth/6]).
+-export([auth/6, auth/5]).
 
 %% Authorize on database synchronously
 -spec auth(float(), port(), database(), binary() | undefined, binary() | undefined, module()) -> ok | {error, term()}.
@@ -35,6 +35,9 @@ auth(Version, Socket, Database, Login, Password, NetModule) when Version > 2.7 -
 auth(_, Socket, Database, Login, Password, NetModule) ->   %old authorisation
   mongodb_cr_auth(Socket, Database, Login, Password, NetModule).
 
+-spec auth(port(), database(), binary() | undefined, binary() | undefined, module()) -> ok | {error, term()}.
+auth(Socket, Database, Login, Password, NetModule) ->  %new authorization
+  scram_sha_1_auth(Socket, Database, Login, Password, NetModule).
 
 %% @private
 -spec mongodb_cr_auth(port(), database(), binary(), binary(), module()) -> ok | {error, term()}.

--- a/src/connection/mc_worker.erl
+++ b/src/connection/mc_worker.erl
@@ -280,5 +280,5 @@ get_set_opts_module(Options) ->
 auth_if_credentials(_, _, _, Login, Password) when Login =:= undefined; Password =:= undefined ->
   ok;
 auth_if_credentials(Socket, ConnState, NetModule, Login, Password) ->
-  Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.auth_source, NetModule),
-  mc_auth_logic:auth(Version, Socket, ConnState#conn_state.auth_source, Login, Password, NetModule).
+%%  Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.auth_source, NetModule),
+  mc_auth_logic:auth(Socket, ConnState#conn_state.auth_source, Login, Password, NetModule).


### PR DESCRIPTION
mc_auth_logic:auth/6 needs Version parameter to check authentication method. drop Version parameter in mc_auth_logic:auth/5 since scram_sha_1_auth is used for Version > 2.7 and remove authentication support to old versions of MongoDB.