### PR TITLE
chore: pin poolboy to emqx fork at tag 1.5.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 
 {deps, [
   {bson, {git, "https://github.com/comtihon/bson-erlang.git", {tag, "v0.2.2"}}},
-  {poolboy, {git, "https://github.com/comtihon/poolboy.git", {branch, "master"}}}
+  {poolboy, {git, "https://github.com/emqx/poolboy.git", {tag, "1.5.2"}}}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
## Summary
Was: \`comtihon/poolboy\` master (untagged, fork-only features that mongodb-erlang doesn't use). Switch to \`emqx/poolboy\` tag \`1.5.2\` — the canonical \`devinus/poolboy\` 1.5.2 release tagged on the emqx fork.

mongodb-erlang only uses \`poolboy:{start_link, transaction, status, stop}\` (grep-confirmed); all unchanged in 1.5.2. Tag 1.5.2 also includes the OTP 21+ stacktrace fix needed for newer OTP versions.

## Test plan
- [x] CI green (compile + xref)