### PR TITLE
fix: skip pre-auth buildInfo probe in get_version/3 (MongoDB 8.0)

### DIFF
--- a/src/connection/mc_worker_logic.erl
+++ b/src/connection/mc_worker_logic.erl
@@ -27,15 +27,12 @@ connect_to_database(Conf) ->
 
 %% Get server version. This is need to choose default authentication method.
 -spec get_version(port(), binary(), module()) -> float().
-get_version(Socket, Database, SetOpts) ->
-  {true, #{<<"version">> := Version}} =
-    mc_worker_api:sync_command(Socket,
-                               Database,
-                               {<<"buildinfo">>, 1},
-                               SetOpts,
-                               mc_utils:use_legacy_protocol(self())),
-  {VFloat, _} = string:to_float(binary_to_list(Version)),
-  VFloat.
+get_version(_Socket, _Database, _SetOpts) ->
+  %% Default to the SCRAM-SHA-1 era (>= 3.0). MongoDB 4.0 removed
+  %% MONGODB-CR (the only thing this probe was deciding for), and
+  %% Mongo 8.0 restricts `buildInfo` to authenticated callers, so
+  %% probing pre-auth fails. Always pick the SCRAM path.
+  3.0.
 
 -spec encode_request(mc_worker_api:database(), mongo_protocol:message()) -> {binary(), pos_integer()}.
 encode_request(Database, Request) ->


### PR DESCRIPTION
## Problem

MongoDB 8.0+ restricts the `buildInfo` command to **authenticated** callers. The driver runs `buildInfo` *before* SCRAM auth (in `mc_worker_logic:get_version/3`) to decide between SCRAM-SHA-1 and the legacy MONGODB-CR mechanism. On MongoDB 8.0 this pre-auth probe fails and the connection cannot be established.

Ref: https://github.com/emqx/emqx/issues/17505

## Fix

`get_version/3` now returns the constant `3.0` instead of probing. The probe only ever selected between SCRAM-SHA-1 (version > 2.7) and MONGODB-CR; MongoDB 4.0 removed MONGODB-CR entirely, so the legacy branch is dead code. `3.0` deterministically selects the SCRAM-SHA-1 path, which all supported MongoDB versions accept.

## Why this approach

Minimal and hot-upgrade-safe:
- Exported arity unchanged (`get_version/3`); the call site in `mc_worker.erl` is untouched.
- `mc_worker_logic` is a stateless helper — single hot-loadable `mc_worker_logic.beam`, no state migration, running workers unaffected.

Tagged as `v3.1.2` for the EMQX release-60 pin.

Note: supersedes the alternative approach in #53, which touches `mc_auth_logic` and the `mc_worker` call site (two beams) and is less suited to a hot patch.